### PR TITLE
Flash links fix

### DIFF
--- a/example/src/stories/Modal/modal.stories.js
+++ b/example/src/stories/Modal/modal.stories.js
@@ -46,7 +46,7 @@ class YourModal extends Component {
             <Button.Text
               icononly
               icon={'Close'}
-              color={'moon-gray'}
+              mainColor={'moon-gray'}
               position={'absolute'}
               top={0}
               right={0}

--- a/src/Button/BaseButton.js
+++ b/src/Button/BaseButton.js
@@ -47,7 +47,6 @@ const StyledButton = styled(Box)`
     text-decoration: none;
     text-align: center;
     overflow: hidden;
-    position: relative;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/Button/__snapshots__/Button.test.js.snap
+++ b/src/Button/__snapshots__/Button.test.js.snap
@@ -54,7 +54,6 @@ exports[`Button Icon component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -221,7 +220,6 @@ exports[`Button Icon component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -398,7 +396,6 @@ exports[`Button Icon only component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -566,7 +563,6 @@ exports[`Button Icon with position prop component sanity matches default snapsho
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -733,7 +729,6 @@ exports[`Button component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -891,7 +886,6 @@ exports[`Button component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1059,7 +1053,6 @@ exports[`Button disabled component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1218,7 +1211,6 @@ exports[`Button disabled component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1388,7 +1380,6 @@ exports[`Button size variant component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1546,7 +1537,6 @@ exports[`Button size variant component sanity matches default snapshot 2`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1705,7 +1695,6 @@ exports[`Button size variant component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -1873,7 +1862,6 @@ exports[`Button size variant component sanity matches themed snapshot 2`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2044,7 +2032,6 @@ exports[`Button.Outline component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2230,7 +2217,6 @@ exports[`Button.Outline component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2419,7 +2405,6 @@ exports[`Button.Text component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2558,7 +2543,6 @@ exports[`Button.Text component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2714,7 +2698,6 @@ exports[`Link Button Outline component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -2902,7 +2885,6 @@ exports[`Link Button component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3065,7 +3047,6 @@ exports[`Loading Button component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -3297,7 +3278,6 @@ exports[`Loading Button component sanity matches default snapshot 2`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/Flash/__snapshots__/Flash.test.js.snap
+++ b/src/Flash/__snapshots__/Flash.test.js.snap
@@ -2086,13 +2086,13 @@ exports[`Select component sanity matches themed snapshot 1`] = `
   position: relative;
 }
 
-.c1 a {
+.c1 .c3 {
   font-size: inherit;
   cursor: pointer;
   color: inherit;
 }
 
-.c1 a:hover {
+.c1 .c3:hover {
   color: inherit;
 }
 

--- a/src/Flash/index.js
+++ b/src/Flash/index.js
@@ -3,8 +3,9 @@ import styled from 'styled-components';
 import { variant } from 'styled-system';
 
 import defaultTheme from '../theme';
-import Text from '../Text';
 import Box from '../Box';
+import Text from '../Text';
+import Link from '../Link';
 
 let lastId = 0;
 const newID = (prefix = 'id') => `${prefix}${lastId++}`;
@@ -20,7 +21,7 @@ const StyledFlash = styled(Box)`
     position: relative;
   }
 
-  a {
+  ${Link} {
     font-size: inherit;
     cursor: pointer;
     color: inherit;

--- a/src/Input/__snapshots__/FileInput.test.js.snap
+++ b/src/Input/__snapshots__/FileInput.test.js.snap
@@ -54,7 +54,6 @@ exports[`File Input component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -249,7 +248,6 @@ exports[`File Input component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/Link/__snapshots__/Link.test.js.snap
+++ b/src/Link/__snapshots__/Link.test.js.snap
@@ -4,12 +4,8 @@ exports[`Link component sanity matches default snapshot 1`] = `
 .c0 {
   color: #4E3FCE;
   font-size: 14px;
-  text-align: left;
   font-size: 14px;
-  font-family: "Source Sans Pro",-apple-system,sans-serif;
   font-weight: 600;
-  text-align: left;
-  line-height: 1.5;
 }
 
 .c0 {
@@ -36,7 +32,6 @@ exports[`Link component sanity matches default snapshot 1`] = `
 <a
   class="c0"
   color="primary"
-  font-family="sansSerif"
   font-size="1"
   font-weight="3"
 />
@@ -46,12 +41,8 @@ exports[`Link component sanity matches themed snapshot 1`] = `
 .c1 {
   color: #4E3FCE;
   font-size: 14px;
-  text-align: left;
   font-size: 14px;
-  font-family: "Source Sans Pro",-apple-system,sans-serif;
   font-weight: 600;
-  text-align: left;
-  line-height: 1.5;
 }
 
 .c1 {
@@ -87,7 +78,6 @@ exports[`Link component sanity matches themed snapshot 1`] = `
   <a
     class="c1"
     color="primary"
-    font-family="sansSerif"
     font-size="1"
     font-weight="3"
   />

--- a/src/Link/index.js
+++ b/src/Link/index.js
@@ -17,7 +17,7 @@ const activeColor = style({
   key: 'colors',
 });
 
-const StyledLink = styled(Text)`
+const Link = styled(Text)`
   & {
     text-decoration: none;
   }
@@ -32,10 +32,6 @@ const StyledLink = styled(Text)`
     ${activeColor};
   }
 `;
-
-const Link = ({ className, children, ...props }) => (
-  <StyledLink className={className} children={children} {...props} />
-);
 
 Link.defaultProps = {
   theme: defaultTheme,

--- a/src/PublicAddress/__snapshots__/PublicAddress.test.js.snap
+++ b/src/PublicAddress/__snapshots__/PublicAddress.test.js.snap
@@ -75,7 +75,6 @@ exports[`PublicAddress component sanity matches default snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -398,7 +397,6 @@ exports[`PublicAddress component sanity matches themed snapshot 1`] = `
   text-decoration: none;
   text-align: center;
   overflow: hidden;
-  position: relative;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;

--- a/src/ToastMessage/__snapshots__/ToastMessage.test.js.snap
+++ b/src/ToastMessage/__snapshots__/ToastMessage.test.js.snap
@@ -1090,12 +1090,8 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
 .c9 {
   color: #4E3FCE;
   font-size: 14px;
-  text-align: left;
   font-size: 14px;
-  font-family: "Source Sans Pro",-apple-system,sans-serif;
   font-weight: 600;
-  text-align: left;
-  line-height: 1.5;
 }
 
 .c9 {
@@ -5055,8 +5051,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         ],
                                         "blue": "#3259D6",
                                         "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
                                         "dark-gray": "#333",
                                         "grey": "#CCC",
+                                        "info": "#36ADF1",
                                         "light-gray": "#eee",
                                         "light-silver": "#aaa",
                                         "mid-gray": "#555",
@@ -5067,7 +5065,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         "primary-dark": "#3e32a4",
                                         "primary-light": "#7165d7",
                                         "silver": "#999",
+                                        "success": "#28C081",
                                         "transparent": "transparent",
+                                        "warning": "#FD9D28",
                                         "white": "#fff",
                                         "whites": Array [
                                           "rgba(255,255,255,.0125)",
@@ -5357,8 +5357,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         ],
                                         "blue": "#3259D6",
                                         "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
                                         "dark-gray": "#333",
                                         "grey": "#CCC",
+                                        "info": "#36ADF1",
                                         "light-gray": "#eee",
                                         "light-silver": "#aaa",
                                         "mid-gray": "#555",
@@ -5369,7 +5371,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         "primary-dark": "#3e32a4",
                                         "primary-light": "#7165d7",
                                         "silver": "#999",
+                                        "success": "#28C081",
                                         "transparent": "transparent",
+                                        "warning": "#FD9D28",
                                         "white": "#fff",
                                         "whites": Array [
                                           "rgba(255,255,255,.0125)",
@@ -5658,8 +5662,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         ],
                                         "blue": "#3259D6",
                                         "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
                                         "dark-gray": "#333",
                                         "grey": "#CCC",
+                                        "info": "#36ADF1",
                                         "light-gray": "#eee",
                                         "light-silver": "#aaa",
                                         "mid-gray": "#555",
@@ -5670,7 +5676,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         "primary-dark": "#3e32a4",
                                         "primary-light": "#7165d7",
                                         "silver": "#999",
+                                        "success": "#28C081",
                                         "transparent": "transparent",
+                                        "warning": "#FD9D28",
                                         "white": "#fff",
                                         "whites": Array [
                                           "rgba(255,255,255,.0125)",
@@ -6898,8 +6906,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         ],
                                         "blue": "#3259D6",
                                         "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
                                         "dark-gray": "#333",
                                         "grey": "#CCC",
+                                        "info": "#36ADF1",
                                         "light-gray": "#eee",
                                         "light-silver": "#aaa",
                                         "mid-gray": "#555",
@@ -6910,7 +6920,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         "primary-dark": "#3e32a4",
                                         "primary-light": "#7165d7",
                                         "silver": "#999",
+                                        "success": "#28C081",
                                         "transparent": "transparent",
+                                        "warning": "#FD9D28",
                                         "white": "#fff",
                                         "whites": Array [
                                           "rgba(255,255,255,.0125)",
@@ -7200,8 +7212,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         ],
                                         "blue": "#3259D6",
                                         "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
                                         "dark-gray": "#333",
                                         "grey": "#CCC",
+                                        "info": "#36ADF1",
                                         "light-gray": "#eee",
                                         "light-silver": "#aaa",
                                         "mid-gray": "#555",
@@ -7212,7 +7226,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         "primary-dark": "#3e32a4",
                                         "primary-light": "#7165d7",
                                         "silver": "#999",
+                                        "success": "#28C081",
                                         "transparent": "transparent",
+                                        "warning": "#FD9D28",
                                         "white": "#fff",
                                         "whites": Array [
                                           "rgba(255,255,255,.0125)",
@@ -7501,8 +7517,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         ],
                                         "blue": "#3259D6",
                                         "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
                                         "dark-gray": "#333",
                                         "grey": "#CCC",
+                                        "info": "#36ADF1",
                                         "light-gray": "#eee",
                                         "light-silver": "#aaa",
                                         "mid-gray": "#555",
@@ -7513,7 +7531,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                         "primary-dark": "#3e32a4",
                                         "primary-light": "#7165d7",
                                         "silver": "#999",
+                                        "success": "#28C081",
                                         "transparent": "transparent",
+                                        "warning": "#FD9D28",
                                         "white": "#fff",
                                         "whites": Array [
                                           "rgba(255,255,255,.0125)",
@@ -8747,8 +8767,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                   ],
                                   "blue": "#3259D6",
                                   "copyColor": "#3F3D4B",
+                                  "danger": "#DC2C10",
                                   "dark-gray": "#333",
                                   "grey": "#CCC",
+                                  "info": "#36ADF1",
                                   "light-gray": "#eee",
                                   "light-silver": "#aaa",
                                   "mid-gray": "#555",
@@ -8759,7 +8781,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                   "primary-dark": "#3e32a4",
                                   "primary-light": "#7165d7",
                                   "silver": "#999",
+                                  "success": "#28C081",
                                   "transparent": "transparent",
+                                  "warning": "#FD9D28",
                                   "white": "#fff",
                                   "whites": Array [
                                     "rgba(255,255,255,.0125)",
@@ -9049,8 +9073,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                   ],
                                   "blue": "#3259D6",
                                   "copyColor": "#3F3D4B",
+                                  "danger": "#DC2C10",
                                   "dark-gray": "#333",
                                   "grey": "#CCC",
+                                  "info": "#36ADF1",
                                   "light-gray": "#eee",
                                   "light-silver": "#aaa",
                                   "mid-gray": "#555",
@@ -9061,7 +9087,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                   "primary-dark": "#3e32a4",
                                   "primary-light": "#7165d7",
                                   "silver": "#999",
+                                  "success": "#28C081",
                                   "transparent": "transparent",
+                                  "warning": "#FD9D28",
                                   "white": "#fff",
                                   "whites": Array [
                                     "rgba(255,255,255,.0125)",
@@ -9350,8 +9378,10 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                   ],
                                   "blue": "#3259D6",
                                   "copyColor": "#3F3D4B",
+                                  "danger": "#DC2C10",
                                   "dark-gray": "#333",
                                   "grey": "#CCC",
+                                  "info": "#36ADF1",
                                   "light-gray": "#eee",
                                   "light-silver": "#aaa",
                                   "mid-gray": "#555",
@@ -9362,7 +9392,9 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                   "primary-dark": "#3e32a4",
                                   "primary-light": "#7165d7",
                                   "silver": "#999",
+                                  "success": "#28C081",
                                   "transparent": "transparent",
+                                  "warning": "#FD9D28",
                                   "white": "#fff",
                                   "whites": Array [
                                     "rgba(255,255,255,.0125)",
@@ -10046,435 +10078,179 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                             }
                           }
                         >
-                          <Styled(Text)
+                          <StyledComponent
                             activeColor="primary-dark"
                             as="a"
                             color="primary"
-                            fontFamily="sansSerif"
                             fontSize={1}
                             fontWeight={3}
-                            hoverColor="primary-light"
-                            href="http://test.com"
-                            lineHeight="copy"
-                            target="_blank"
-                            textAlign="left"
-                            theme={
+                            forwardedComponent={
                               Object {
-                                "borderWidths": Array [
-                                  "0",
-                                  "1px",
-                                  "2px",
-                                  "4px",
-                                ],
-                                "borders": Array [
-                                  0,
-                                  "1px solid transparent",
-                                ],
-                                "buttonSizes": Object {
-                                  "large": Object {
-                                    "fontSize": "1.5rem",
-                                    "height": "4rem",
-                                    "minWidth": "4rem",
-                                  },
-                                  "medium": Object {
-                                    "fontSize": "1rem",
-                                    "height": "3rem",
-                                    "minWidth": "3rem",
-                                  },
-                                  "small": Object {
-                                    "fontSize": "0.75rem",
-                                    "height": "2rem",
-                                    "minWidth": "2rem",
-                                    "padding": "0 1rem",
-                                  },
-                                },
-                                "buttons": Object {
-                                  "danger": Object {
-                                    "--contrast-color": "#fff",
-                                    "--main-color": "#DC2C10",
-                                  },
-                                  "primary": Object {
-                                    "--contrast-color": "#fff",
-                                    "--main-color": "#4E3FCE",
-                                    "backgroundColor": "#4E3FCE",
-                                    "color": "#fff",
-                                  },
-                                  "success": Object {
-                                    "--contrast-color": "#FFF",
-                                    "--main-color": "#28C081",
-                                  },
-                                },
-                                "colors": Object {
-                                  "black": "#000e1a",
-                                  "blacks": Array [
-                                    "rgba(0,0,0,.0125)",
-                                    "rgba(0,0,0,.025)",
-                                    "rgba(0,0,0,.05)",
-                                    "rgba(0,0,0,.1)",
-                                    "rgba(0,0,0,.2)",
-                                    "rgba(0,0,0,.3)",
-                                    "rgba(0,0,0,.4)",
-                                    "rgba(0,0,0,.5)",
-                                    "rgba(0,0,0,.6)",
-                                    "rgba(0,0,0,.7)",
-                                    "rgba(0,0,0,.8)",
-                                    "rgba(0,0,0,.9)",
-                                  ],
-                                  "blue": "#3259D6",
-                                  "copyColor": "#3F3D4B",
-                                  "danger": "#DC2C10",
-                                  "dark-gray": "#333",
-                                  "grey": "#CCC",
-                                  "info": "#36ADF1",
-                                  "light-gray": "#eee",
-                                  "light-silver": "#aaa",
-                                  "mid-gray": "#555",
-                                  "moon-gray": "#ccc",
-                                  "near-black": "#111",
-                                  "near-white": "#f4f4f4",
-                                  "primary": "#4E3FCE",
-                                  "primary-dark": "#3e32a4",
-                                  "primary-light": "#7165d7",
-                                  "silver": "#999",
-                                  "success": "#28C081",
-                                  "transparent": "transparent",
-                                  "warning": "#FD9D28",
-                                  "white": "#fff",
-                                  "whites": Array [
-                                    "rgba(255,255,255,.0125)",
-                                    "rgba(255,255,255,.025)",
-                                    "rgba(255,255,255,.05)",
-                                    "rgba(255,255,255,.1)",
-                                    "rgba(255,255,255,.2)",
-                                    "rgba(255,255,255,.3)",
-                                    "rgba(255,255,255,.4)",
-                                    "rgba(255,255,255,.5)",
-                                    "rgba(255,255,255,.6)",
-                                    "rgba(255,255,255,.7)",
-                                    "rgba(255,255,255,.8)",
-                                    "rgba(255,255,255,.9)",
-                                  ],
-                                },
-                                "fontSizes": Array [
-                                  12,
-                                  14,
-                                  16,
-                                  20,
-                                  24,
-                                  32,
-                                  48,
-                                  64,
-                                ],
-                                "fontWeights": Array [
-                                  0,
-                                  300,
-                                  400,
-                                  600,
-                                  700,
-                                ],
-                                "fonts": Object {
-                                  "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
-                                  "serif": "athelas, georgia, times, serif",
-                                },
-                                "heights": Array [
-                                  0,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                ],
-                                "letterSpacings": Array [
-                                  0,
-                                  1,
-                                  2,
-                                  4,
-                                  8,
-                                ],
-                                "lineHeights": Object {
-                                  "copy": 1.5,
-                                  "solid": 1,
-                                  "title": 1.25,
-                                },
-                                "maxHeights": Array [
-                                  0,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                ],
-                                "maxWidths": Array [
-                                  0,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                  512,
-                                  768,
-                                  1024,
-                                  1536,
-                                ],
-                                "messageStyle": Object {
-                                  "base": Object {
-                                    "backgroundColor": "#f6f6f6",
-                                    "borderColor": "#AAA",
-                                    "color": "#666",
-                                  },
-                                  "danger": Object {
-                                    "backgroundColor": "#fbe9e7",
-                                    "borderColor": "#DC2C10",
-                                    "color": "#841a09",
-                                  },
-                                  "info": Object {
-                                    "backgroundColor": "#eaf6fd",
-                                    "borderColor": "#36ADF1",
-                                    "color": "#206790",
-                                  },
-                                  "success": Object {
-                                    "backgroundColor": "#e9f8f2",
-                                    "borderColor": "#28C081",
-                                    "color": "#18734d",
-                                  },
-                                  "warning": Object {
-                                    "backgroundColor": "#fef5e9",
-                                    "borderColor": "#FD9D28",
-                                    "color": "#975e18",
-                                  },
-                                },
-                                "minHeights": Array [
-                                  0,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                ],
-                                "minWidths": Array [
-                                  0,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                ],
-                                "opacity": Object {
-                                  "disabled": 0.4,
-                                },
-                                "radii": Array [
-                                  "0",
-                                  "4px",
-                                  "8px",
-                                  "16px",
-                                ],
-                                "shadows": Array [
-                                  "0",
-                                  "0px 2px 4px rgba(0, 0, 0, 0.1)",
-                                  "0 7px 14px rgba(50,50,93,.1)",
-                                ],
-                                "space": Array [
-                                  0,
-                                  4,
-                                  8,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                ],
-                                "width": Array [
-                                  0,
-                                  16,
-                                  32,
-                                  64,
-                                  128,
-                                  256,
-                                ],
-                                "zIndices": Array [
-                                  0,
-                                  9,
-                                  99,
-                                  999,
-                                  9999,
-                                ],
-                              }
-                            }
-                          >
-                            <StyledComponent
-                              activeColor="primary-dark"
-                              as="a"
-                              color="primary"
-                              fontFamily="sansSerif"
-                              fontSize={1}
-                              fontWeight={3}
-                              forwardedComponent={
-                                Object {
-                                  "$$typeof": Symbol(react.forward_ref),
-                                  "attrs": Array [],
-                                  "componentStyle": ComponentStyle {
-                                    "componentId": "sc-bGbZqa",
-                                    "isStatic": false,
-                                    "lastClassName": "c9",
-                                    "rules": Array [
-                                      "
+                                "$$typeof": Symbol(react.forward_ref),
+                                "attrs": Array [],
+                                "componentStyle": ComponentStyle {
+                                  "componentId": "sc-bGbZqa",
+                                  "isStatic": false,
+                                  "lastClassName": "c9",
+                                  "rules": Array [
+                                    "
   & {
     box-sizing: border-box;
   }
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
 ",
-                                      "
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
 
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
   ",
-                                      [Function],
-                                      "
+                                    [Function],
+                                    "
 ",
-                                      "
+                                    "
   & {
     text-decoration: none;
   }
@@ -10482,16 +10258,317 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
   &:hover {
     text-decoration: underline;
     ",
-                                      [Function],
-                                      ";
+                                    [Function],
+                                    ";
   }
 
   &:active {
     text-decoration: none;
     ",
-                                      [Function],
-                                      ";
+                                    [Function],
+                                    ";
   }
+",
+                                  ],
+                                },
+                                "defaultProps": Object {
+                                  "activeColor": "primary-dark",
+                                  "as": "a",
+                                  "color": "primary",
+                                  "fontSize": 1,
+                                  "fontWeight": 3,
+                                  "hoverColor": "primary-light",
+                                  "theme": Object {
+                                    "borderWidths": Array [
+                                      "0",
+                                      "1px",
+                                      "2px",
+                                      "4px",
+                                    ],
+                                    "borders": Array [
+                                      0,
+                                      "1px solid transparent",
+                                    ],
+                                    "buttonSizes": Object {
+                                      "large": Object {
+                                        "fontSize": "1.5rem",
+                                        "height": "4rem",
+                                        "minWidth": "4rem",
+                                      },
+                                      "medium": Object {
+                                        "fontSize": "1rem",
+                                        "height": "3rem",
+                                        "minWidth": "3rem",
+                                      },
+                                      "small": Object {
+                                        "fontSize": "0.75rem",
+                                        "height": "2rem",
+                                        "minWidth": "2rem",
+                                        "padding": "0 1rem",
+                                      },
+                                    },
+                                    "buttons": Object {
+                                      "danger": Object {
+                                        "--contrast-color": "#fff",
+                                        "--main-color": "#DC2C10",
+                                      },
+                                      "primary": Object {
+                                        "--contrast-color": "#fff",
+                                        "--main-color": "#4E3FCE",
+                                        "backgroundColor": "#4E3FCE",
+                                        "color": "#fff",
+                                      },
+                                      "success": Object {
+                                        "--contrast-color": "#FFF",
+                                        "--main-color": "#28C081",
+                                      },
+                                    },
+                                    "colors": Object {
+                                      "black": "#000e1a",
+                                      "blacks": Array [
+                                        "rgba(0,0,0,.0125)",
+                                        "rgba(0,0,0,.025)",
+                                        "rgba(0,0,0,.05)",
+                                        "rgba(0,0,0,.1)",
+                                        "rgba(0,0,0,.2)",
+                                        "rgba(0,0,0,.3)",
+                                        "rgba(0,0,0,.4)",
+                                        "rgba(0,0,0,.5)",
+                                        "rgba(0,0,0,.6)",
+                                        "rgba(0,0,0,.7)",
+                                        "rgba(0,0,0,.8)",
+                                        "rgba(0,0,0,.9)",
+                                      ],
+                                      "blue": "#3259D6",
+                                      "copyColor": "#3F3D4B",
+                                      "danger": "#DC2C10",
+                                      "dark-gray": "#333",
+                                      "grey": "#CCC",
+                                      "info": "#36ADF1",
+                                      "light-gray": "#eee",
+                                      "light-silver": "#aaa",
+                                      "mid-gray": "#555",
+                                      "moon-gray": "#ccc",
+                                      "near-black": "#111",
+                                      "near-white": "#f4f4f4",
+                                      "primary": "#4E3FCE",
+                                      "primary-dark": "#3e32a4",
+                                      "primary-light": "#7165d7",
+                                      "silver": "#999",
+                                      "success": "#28C081",
+                                      "transparent": "transparent",
+                                      "warning": "#FD9D28",
+                                      "white": "#fff",
+                                      "whites": Array [
+                                        "rgba(255,255,255,.0125)",
+                                        "rgba(255,255,255,.025)",
+                                        "rgba(255,255,255,.05)",
+                                        "rgba(255,255,255,.1)",
+                                        "rgba(255,255,255,.2)",
+                                        "rgba(255,255,255,.3)",
+                                        "rgba(255,255,255,.4)",
+                                        "rgba(255,255,255,.5)",
+                                        "rgba(255,255,255,.6)",
+                                        "rgba(255,255,255,.7)",
+                                        "rgba(255,255,255,.8)",
+                                        "rgba(255,255,255,.9)",
+                                      ],
+                                    },
+                                    "fontSizes": Array [
+                                      12,
+                                      14,
+                                      16,
+                                      20,
+                                      24,
+                                      32,
+                                      48,
+                                      64,
+                                    ],
+                                    "fontWeights": Array [
+                                      0,
+                                      300,
+                                      400,
+                                      600,
+                                      700,
+                                    ],
+                                    "fonts": Object {
+                                      "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
+                                      "serif": "athelas, georgia, times, serif",
+                                    },
+                                    "heights": Array [
+                                      0,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                    ],
+                                    "letterSpacings": Array [
+                                      0,
+                                      1,
+                                      2,
+                                      4,
+                                      8,
+                                    ],
+                                    "lineHeights": Object {
+                                      "copy": 1.5,
+                                      "solid": 1,
+                                      "title": 1.25,
+                                    },
+                                    "maxHeights": Array [
+                                      0,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                    ],
+                                    "maxWidths": Array [
+                                      0,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                      512,
+                                      768,
+                                      1024,
+                                      1536,
+                                    ],
+                                    "messageStyle": Object {
+                                      "base": Object {
+                                        "backgroundColor": "#f6f6f6",
+                                        "borderColor": "#AAA",
+                                        "color": "#666",
+                                      },
+                                      "danger": Object {
+                                        "backgroundColor": "#fbe9e7",
+                                        "borderColor": "#DC2C10",
+                                        "color": "#841a09",
+                                      },
+                                      "info": Object {
+                                        "backgroundColor": "#eaf6fd",
+                                        "borderColor": "#36ADF1",
+                                        "color": "#206790",
+                                      },
+                                      "success": Object {
+                                        "backgroundColor": "#e9f8f2",
+                                        "borderColor": "#28C081",
+                                        "color": "#18734d",
+                                      },
+                                      "warning": Object {
+                                        "backgroundColor": "#fef5e9",
+                                        "borderColor": "#FD9D28",
+                                        "color": "#975e18",
+                                      },
+                                    },
+                                    "minHeights": Array [
+                                      0,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                    ],
+                                    "minWidths": Array [
+                                      0,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                    ],
+                                    "opacity": Object {
+                                      "disabled": 0.4,
+                                    },
+                                    "radii": Array [
+                                      "0",
+                                      "4px",
+                                      "8px",
+                                      "16px",
+                                    ],
+                                    "shadows": Array [
+                                      "0",
+                                      "0px 2px 4px rgba(0, 0, 0, 0.1)",
+                                      "0 7px 14px rgba(50,50,93,.1)",
+                                    ],
+                                    "space": Array [
+                                      0,
+                                      4,
+                                      8,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                    ],
+                                    "width": Array [
+                                      0,
+                                      16,
+                                      32,
+                                      64,
+                                      128,
+                                      256,
+                                    ],
+                                    "zIndices": Array [
+                                      0,
+                                      9,
+                                      99,
+                                      999,
+                                      9999,
+                                    ],
+                                  },
+                                },
+                                "displayName": "Link",
+                                "foldedComponentIds": Array [
+                                  "sc-bdVaJa",
+                                  "c5",
+                                ],
+                                "p": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-gQORMK",
+                                    "isStatic": false,
+                                    "rules": Array [
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
 ",
                                     ],
                                   },
@@ -10743,1184 +10820,891 @@ exports[`ToastMessage component sanity matches full component mount snapshot 1`]
                                       ],
                                     },
                                   },
-                                  "displayName": "Styled(Text)",
-                                  "foldedComponentIds": Array [
-                                    "sc-bdVaJa",
-                                    "c5",
-                                  ],
-                                  "p": Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "attrs": Array [],
-                                    "componentStyle": ComponentStyle {
-                                      "componentId": "sc-gQORMK",
-                                      "isStatic": false,
-                                      "rules": Array [
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-",
-                                      ],
-                                    },
-                                    "defaultProps": Object {
-                                      "color": "copyColor",
-                                      "fontFamily": "sansSerif",
-                                      "fontSize": 2,
-                                      "fontWeight": 2,
-                                      "lineHeight": "copy",
-                                      "textAlign": "left",
-                                      "theme": Object {
-                                        "borderWidths": Array [
-                                          "0",
-                                          "1px",
-                                          "2px",
-                                          "4px",
-                                        ],
-                                        "borders": Array [
-                                          0,
-                                          "1px solid transparent",
-                                        ],
-                                        "buttonSizes": Object {
-                                          "large": Object {
-                                            "fontSize": "1.5rem",
-                                            "height": "4rem",
-                                            "minWidth": "4rem",
-                                          },
-                                          "medium": Object {
-                                            "fontSize": "1rem",
-                                            "height": "3rem",
-                                            "minWidth": "3rem",
-                                          },
-                                          "small": Object {
-                                            "fontSize": "0.75rem",
-                                            "height": "2rem",
-                                            "minWidth": "2rem",
-                                            "padding": "0 1rem",
-                                          },
-                                        },
-                                        "buttons": Object {
-                                          "danger": Object {
-                                            "--contrast-color": "#fff",
-                                            "--main-color": "#DC2C10",
-                                          },
-                                          "primary": Object {
-                                            "--contrast-color": "#fff",
-                                            "--main-color": "#4E3FCE",
-                                            "backgroundColor": "#4E3FCE",
-                                            "color": "#fff",
-                                          },
-                                          "success": Object {
-                                            "--contrast-color": "#FFF",
-                                            "--main-color": "#28C081",
-                                          },
-                                        },
-                                        "colors": Object {
-                                          "black": "#000e1a",
-                                          "blacks": Array [
-                                            "rgba(0,0,0,.0125)",
-                                            "rgba(0,0,0,.025)",
-                                            "rgba(0,0,0,.05)",
-                                            "rgba(0,0,0,.1)",
-                                            "rgba(0,0,0,.2)",
-                                            "rgba(0,0,0,.3)",
-                                            "rgba(0,0,0,.4)",
-                                            "rgba(0,0,0,.5)",
-                                            "rgba(0,0,0,.6)",
-                                            "rgba(0,0,0,.7)",
-                                            "rgba(0,0,0,.8)",
-                                            "rgba(0,0,0,.9)",
-                                          ],
-                                          "blue": "#3259D6",
-                                          "copyColor": "#3F3D4B",
-                                          "dark-gray": "#333",
-                                          "grey": "#CCC",
-                                          "light-gray": "#eee",
-                                          "light-silver": "#aaa",
-                                          "mid-gray": "#555",
-                                          "moon-gray": "#ccc",
-                                          "near-black": "#111",
-                                          "near-white": "#f4f4f4",
-                                          "primary": "#4E3FCE",
-                                          "primary-dark": "#3e32a4",
-                                          "primary-light": "#7165d7",
-                                          "silver": "#999",
-                                          "transparent": "transparent",
-                                          "white": "#fff",
-                                          "whites": Array [
-                                            "rgba(255,255,255,.0125)",
-                                            "rgba(255,255,255,.025)",
-                                            "rgba(255,255,255,.05)",
-                                            "rgba(255,255,255,.1)",
-                                            "rgba(255,255,255,.2)",
-                                            "rgba(255,255,255,.3)",
-                                            "rgba(255,255,255,.4)",
-                                            "rgba(255,255,255,.5)",
-                                            "rgba(255,255,255,.6)",
-                                            "rgba(255,255,255,.7)",
-                                            "rgba(255,255,255,.8)",
-                                            "rgba(255,255,255,.9)",
-                                          ],
-                                        },
-                                        "fontSizes": Array [
-                                          12,
-                                          14,
-                                          16,
-                                          20,
-                                          24,
-                                          32,
-                                          48,
-                                          64,
-                                        ],
-                                        "fontWeights": Array [
-                                          0,
-                                          300,
-                                          400,
-                                          600,
-                                          700,
-                                        ],
-                                        "fonts": Object {
-                                          "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
-                                          "serif": "athelas, georgia, times, serif",
-                                        },
-                                        "heights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "letterSpacings": Array [
-                                          0,
-                                          1,
-                                          2,
-                                          4,
-                                          8,
-                                        ],
-                                        "lineHeights": Object {
-                                          "copy": 1.5,
-                                          "solid": 1,
-                                          "title": 1.25,
-                                        },
-                                        "maxHeights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "maxWidths": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                          512,
-                                          768,
-                                          1024,
-                                          1536,
-                                        ],
-                                        "messageStyle": Object {
-                                          "base": Object {
-                                            "backgroundColor": "#f6f6f6",
-                                            "borderColor": "#AAA",
-                                            "color": "#666",
-                                          },
-                                          "danger": Object {
-                                            "backgroundColor": "#fbe9e7",
-                                            "borderColor": "#DC2C10",
-                                            "color": "#841a09",
-                                          },
-                                          "info": Object {
-                                            "backgroundColor": "#eaf6fd",
-                                            "borderColor": "#36ADF1",
-                                            "color": "#206790",
-                                          },
-                                          "success": Object {
-                                            "backgroundColor": "#e9f8f2",
-                                            "borderColor": "#28C081",
-                                            "color": "#18734d",
-                                          },
-                                          "warning": Object {
-                                            "backgroundColor": "#fef5e9",
-                                            "borderColor": "#FD9D28",
-                                            "color": "#975e18",
-                                          },
-                                        },
-                                        "minHeights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "minWidths": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "opacity": Object {
-                                          "disabled": 0.4,
-                                        },
-                                        "radii": Array [
-                                          "0",
-                                          "4px",
-                                          "8px",
-                                          "16px",
-                                        ],
-                                        "shadows": Array [
-                                          "0",
-                                          "0px 2px 4px rgba(0, 0, 0, 0.1)",
-                                          "0 7px 14px rgba(50,50,93,.1)",
-                                        ],
-                                        "space": Array [
-                                          0,
-                                          4,
-                                          8,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "width": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "zIndices": Array [
-                                          0,
-                                          9,
-                                          99,
-                                          999,
-                                          9999,
-                                        ],
-                                      },
-                                    },
-                                    "displayName": "styled.p",
-                                    "foldedComponentIds": Array [],
-                                    "render": [Function],
-                                    "styledComponentId": "sc-gQORMK",
-                                    "target": "p",
-                                    "toString": [Function],
-                                    "warnTooManyClasses": [Function],
-                                    "withComponent": [Function],
-                                  },
+                                  "displayName": "styled.p",
+                                  "foldedComponentIds": Array [],
                                   "render": [Function],
-                                  "s": Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "attrs": Array [],
-                                    "componentStyle": ComponentStyle {
-                                      "componentId": "sc-eiqfgm",
-                                      "isStatic": false,
-                                      "rules": Array [
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-",
-                                      ],
-                                    },
-                                    "defaultProps": Object {
-                                      "color": "copyColor",
-                                      "fontFamily": "sansSerif",
-                                      "fontSize": 2,
-                                      "fontWeight": 2,
-                                      "lineHeight": "copy",
-                                      "textAlign": "left",
-                                      "theme": Object {
-                                        "borderWidths": Array [
-                                          "0",
-                                          "1px",
-                                          "2px",
-                                          "4px",
-                                        ],
-                                        "borders": Array [
-                                          0,
-                                          "1px solid transparent",
-                                        ],
-                                        "buttonSizes": Object {
-                                          "large": Object {
-                                            "fontSize": "1.5rem",
-                                            "height": "4rem",
-                                            "minWidth": "4rem",
-                                          },
-                                          "medium": Object {
-                                            "fontSize": "1rem",
-                                            "height": "3rem",
-                                            "minWidth": "3rem",
-                                          },
-                                          "small": Object {
-                                            "fontSize": "0.75rem",
-                                            "height": "2rem",
-                                            "minWidth": "2rem",
-                                            "padding": "0 1rem",
-                                          },
-                                        },
-                                        "buttons": Object {
-                                          "danger": Object {
-                                            "--contrast-color": "#fff",
-                                            "--main-color": "#DC2C10",
-                                          },
-                                          "primary": Object {
-                                            "--contrast-color": "#fff",
-                                            "--main-color": "#4E3FCE",
-                                            "backgroundColor": "#4E3FCE",
-                                            "color": "#fff",
-                                          },
-                                          "success": Object {
-                                            "--contrast-color": "#FFF",
-                                            "--main-color": "#28C081",
-                                          },
-                                        },
-                                        "colors": Object {
-                                          "black": "#000e1a",
-                                          "blacks": Array [
-                                            "rgba(0,0,0,.0125)",
-                                            "rgba(0,0,0,.025)",
-                                            "rgba(0,0,0,.05)",
-                                            "rgba(0,0,0,.1)",
-                                            "rgba(0,0,0,.2)",
-                                            "rgba(0,0,0,.3)",
-                                            "rgba(0,0,0,.4)",
-                                            "rgba(0,0,0,.5)",
-                                            "rgba(0,0,0,.6)",
-                                            "rgba(0,0,0,.7)",
-                                            "rgba(0,0,0,.8)",
-                                            "rgba(0,0,0,.9)",
-                                          ],
-                                          "blue": "#3259D6",
-                                          "copyColor": "#3F3D4B",
-                                          "dark-gray": "#333",
-                                          "grey": "#CCC",
-                                          "light-gray": "#eee",
-                                          "light-silver": "#aaa",
-                                          "mid-gray": "#555",
-                                          "moon-gray": "#ccc",
-                                          "near-black": "#111",
-                                          "near-white": "#f4f4f4",
-                                          "primary": "#4E3FCE",
-                                          "primary-dark": "#3e32a4",
-                                          "primary-light": "#7165d7",
-                                          "silver": "#999",
-                                          "transparent": "transparent",
-                                          "white": "#fff",
-                                          "whites": Array [
-                                            "rgba(255,255,255,.0125)",
-                                            "rgba(255,255,255,.025)",
-                                            "rgba(255,255,255,.05)",
-                                            "rgba(255,255,255,.1)",
-                                            "rgba(255,255,255,.2)",
-                                            "rgba(255,255,255,.3)",
-                                            "rgba(255,255,255,.4)",
-                                            "rgba(255,255,255,.5)",
-                                            "rgba(255,255,255,.6)",
-                                            "rgba(255,255,255,.7)",
-                                            "rgba(255,255,255,.8)",
-                                            "rgba(255,255,255,.9)",
-                                          ],
-                                        },
-                                        "fontSizes": Array [
-                                          12,
-                                          14,
-                                          16,
-                                          20,
-                                          24,
-                                          32,
-                                          48,
-                                          64,
-                                        ],
-                                        "fontWeights": Array [
-                                          0,
-                                          300,
-                                          400,
-                                          600,
-                                          700,
-                                        ],
-                                        "fonts": Object {
-                                          "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
-                                          "serif": "athelas, georgia, times, serif",
-                                        },
-                                        "heights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "letterSpacings": Array [
-                                          0,
-                                          1,
-                                          2,
-                                          4,
-                                          8,
-                                        ],
-                                        "lineHeights": Object {
-                                          "copy": 1.5,
-                                          "solid": 1,
-                                          "title": 1.25,
-                                        },
-                                        "maxHeights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "maxWidths": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                          512,
-                                          768,
-                                          1024,
-                                          1536,
-                                        ],
-                                        "messageStyle": Object {
-                                          "base": Object {
-                                            "backgroundColor": "#f6f6f6",
-                                            "borderColor": "#AAA",
-                                            "color": "#666",
-                                          },
-                                          "danger": Object {
-                                            "backgroundColor": "#fbe9e7",
-                                            "borderColor": "#DC2C10",
-                                            "color": "#841a09",
-                                          },
-                                          "info": Object {
-                                            "backgroundColor": "#eaf6fd",
-                                            "borderColor": "#36ADF1",
-                                            "color": "#206790",
-                                          },
-                                          "success": Object {
-                                            "backgroundColor": "#e9f8f2",
-                                            "borderColor": "#28C081",
-                                            "color": "#18734d",
-                                          },
-                                          "warning": Object {
-                                            "backgroundColor": "#fef5e9",
-                                            "borderColor": "#FD9D28",
-                                            "color": "#975e18",
-                                          },
-                                        },
-                                        "minHeights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "minWidths": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "opacity": Object {
-                                          "disabled": 0.4,
-                                        },
-                                        "radii": Array [
-                                          "0",
-                                          "4px",
-                                          "8px",
-                                          "16px",
-                                        ],
-                                        "shadows": Array [
-                                          "0",
-                                          "0px 2px 4px rgba(0, 0, 0, 0.1)",
-                                          "0 7px 14px rgba(50,50,93,.1)",
-                                        ],
-                                        "space": Array [
-                                          0,
-                                          4,
-                                          8,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "width": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "zIndices": Array [
-                                          0,
-                                          9,
-                                          99,
-                                          999,
-                                          9999,
-                                        ],
-                                      },
-                                    },
-                                    "displayName": "styled.s",
-                                    "foldedComponentIds": Array [],
-                                    "render": [Function],
-                                    "styledComponentId": "sc-eiqfgm",
-                                    "target": "s",
-                                    "toString": [Function],
-                                    "warnTooManyClasses": [Function],
-                                    "withComponent": [Function],
-                                  },
-                                  "span": Object {
-                                    "$$typeof": Symbol(react.forward_ref),
-                                    "attrs": Array [],
-                                    "componentStyle": ComponentStyle {
-                                      "componentId": "sc-jZIEzD",
-                                      "isStatic": false,
-                                      "rules": Array [
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-  ",
-                                        [Function],
-                                        "
-",
-                                      ],
-                                    },
-                                    "defaultProps": Object {
-                                      "color": "copyColor",
-                                      "fontFamily": "sansSerif",
-                                      "fontSize": 2,
-                                      "fontWeight": 2,
-                                      "lineHeight": "copy",
-                                      "textAlign": "left",
-                                      "theme": Object {
-                                        "borderWidths": Array [
-                                          "0",
-                                          "1px",
-                                          "2px",
-                                          "4px",
-                                        ],
-                                        "borders": Array [
-                                          0,
-                                          "1px solid transparent",
-                                        ],
-                                        "buttonSizes": Object {
-                                          "large": Object {
-                                            "fontSize": "1.5rem",
-                                            "height": "4rem",
-                                            "minWidth": "4rem",
-                                          },
-                                          "medium": Object {
-                                            "fontSize": "1rem",
-                                            "height": "3rem",
-                                            "minWidth": "3rem",
-                                          },
-                                          "small": Object {
-                                            "fontSize": "0.75rem",
-                                            "height": "2rem",
-                                            "minWidth": "2rem",
-                                            "padding": "0 1rem",
-                                          },
-                                        },
-                                        "buttons": Object {
-                                          "danger": Object {
-                                            "--contrast-color": "#fff",
-                                            "--main-color": "#DC2C10",
-                                          },
-                                          "primary": Object {
-                                            "--contrast-color": "#fff",
-                                            "--main-color": "#4E3FCE",
-                                            "backgroundColor": "#4E3FCE",
-                                            "color": "#fff",
-                                          },
-                                          "success": Object {
-                                            "--contrast-color": "#FFF",
-                                            "--main-color": "#28C081",
-                                          },
-                                        },
-                                        "colors": Object {
-                                          "black": "#000e1a",
-                                          "blacks": Array [
-                                            "rgba(0,0,0,.0125)",
-                                            "rgba(0,0,0,.025)",
-                                            "rgba(0,0,0,.05)",
-                                            "rgba(0,0,0,.1)",
-                                            "rgba(0,0,0,.2)",
-                                            "rgba(0,0,0,.3)",
-                                            "rgba(0,0,0,.4)",
-                                            "rgba(0,0,0,.5)",
-                                            "rgba(0,0,0,.6)",
-                                            "rgba(0,0,0,.7)",
-                                            "rgba(0,0,0,.8)",
-                                            "rgba(0,0,0,.9)",
-                                          ],
-                                          "blue": "#3259D6",
-                                          "copyColor": "#3F3D4B",
-                                          "dark-gray": "#333",
-                                          "grey": "#CCC",
-                                          "light-gray": "#eee",
-                                          "light-silver": "#aaa",
-                                          "mid-gray": "#555",
-                                          "moon-gray": "#ccc",
-                                          "near-black": "#111",
-                                          "near-white": "#f4f4f4",
-                                          "primary": "#4E3FCE",
-                                          "primary-dark": "#3e32a4",
-                                          "primary-light": "#7165d7",
-                                          "silver": "#999",
-                                          "transparent": "transparent",
-                                          "white": "#fff",
-                                          "whites": Array [
-                                            "rgba(255,255,255,.0125)",
-                                            "rgba(255,255,255,.025)",
-                                            "rgba(255,255,255,.05)",
-                                            "rgba(255,255,255,.1)",
-                                            "rgba(255,255,255,.2)",
-                                            "rgba(255,255,255,.3)",
-                                            "rgba(255,255,255,.4)",
-                                            "rgba(255,255,255,.5)",
-                                            "rgba(255,255,255,.6)",
-                                            "rgba(255,255,255,.7)",
-                                            "rgba(255,255,255,.8)",
-                                            "rgba(255,255,255,.9)",
-                                          ],
-                                        },
-                                        "fontSizes": Array [
-                                          12,
-                                          14,
-                                          16,
-                                          20,
-                                          24,
-                                          32,
-                                          48,
-                                          64,
-                                        ],
-                                        "fontWeights": Array [
-                                          0,
-                                          300,
-                                          400,
-                                          600,
-                                          700,
-                                        ],
-                                        "fonts": Object {
-                                          "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
-                                          "serif": "athelas, georgia, times, serif",
-                                        },
-                                        "heights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "letterSpacings": Array [
-                                          0,
-                                          1,
-                                          2,
-                                          4,
-                                          8,
-                                        ],
-                                        "lineHeights": Object {
-                                          "copy": 1.5,
-                                          "solid": 1,
-                                          "title": 1.25,
-                                        },
-                                        "maxHeights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "maxWidths": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                          512,
-                                          768,
-                                          1024,
-                                          1536,
-                                        ],
-                                        "messageStyle": Object {
-                                          "base": Object {
-                                            "backgroundColor": "#f6f6f6",
-                                            "borderColor": "#AAA",
-                                            "color": "#666",
-                                          },
-                                          "danger": Object {
-                                            "backgroundColor": "#fbe9e7",
-                                            "borderColor": "#DC2C10",
-                                            "color": "#841a09",
-                                          },
-                                          "info": Object {
-                                            "backgroundColor": "#eaf6fd",
-                                            "borderColor": "#36ADF1",
-                                            "color": "#206790",
-                                          },
-                                          "success": Object {
-                                            "backgroundColor": "#e9f8f2",
-                                            "borderColor": "#28C081",
-                                            "color": "#18734d",
-                                          },
-                                          "warning": Object {
-                                            "backgroundColor": "#fef5e9",
-                                            "borderColor": "#FD9D28",
-                                            "color": "#975e18",
-                                          },
-                                        },
-                                        "minHeights": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "minWidths": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "opacity": Object {
-                                          "disabled": 0.4,
-                                        },
-                                        "radii": Array [
-                                          "0",
-                                          "4px",
-                                          "8px",
-                                          "16px",
-                                        ],
-                                        "shadows": Array [
-                                          "0",
-                                          "0px 2px 4px rgba(0, 0, 0, 0.1)",
-                                          "0 7px 14px rgba(50,50,93,.1)",
-                                        ],
-                                        "space": Array [
-                                          0,
-                                          4,
-                                          8,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "width": Array [
-                                          0,
-                                          16,
-                                          32,
-                                          64,
-                                          128,
-                                          256,
-                                        ],
-                                        "zIndices": Array [
-                                          0,
-                                          9,
-                                          99,
-                                          999,
-                                          9999,
-                                        ],
-                                      },
-                                    },
-                                    "displayName": "styled.span",
-                                    "foldedComponentIds": Array [],
-                                    "render": [Function],
-                                    "styledComponentId": "sc-jZIEzD",
-                                    "target": "span",
-                                    "toString": [Function],
-                                    "warnTooManyClasses": [Function],
-                                    "withComponent": [Function],
-                                  },
-                                  "styledComponentId": "sc-bGbZqa",
-                                  "target": "div",
+                                  "styledComponentId": "sc-gQORMK",
+                                  "target": "p",
                                   "toString": [Function],
                                   "warnTooManyClasses": [Function],
                                   "withComponent": [Function],
-                                }
+                                },
+                                "render": [Function],
+                                "s": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-eiqfgm",
+                                    "isStatic": false,
+                                    "rules": Array [
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+",
+                                    ],
+                                  },
+                                  "defaultProps": Object {
+                                    "color": "copyColor",
+                                    "fontFamily": "sansSerif",
+                                    "fontSize": 2,
+                                    "fontWeight": 2,
+                                    "lineHeight": "copy",
+                                    "textAlign": "left",
+                                    "theme": Object {
+                                      "borderWidths": Array [
+                                        "0",
+                                        "1px",
+                                        "2px",
+                                        "4px",
+                                      ],
+                                      "borders": Array [
+                                        0,
+                                        "1px solid transparent",
+                                      ],
+                                      "buttonSizes": Object {
+                                        "large": Object {
+                                          "fontSize": "1.5rem",
+                                          "height": "4rem",
+                                          "minWidth": "4rem",
+                                        },
+                                        "medium": Object {
+                                          "fontSize": "1rem",
+                                          "height": "3rem",
+                                          "minWidth": "3rem",
+                                        },
+                                        "small": Object {
+                                          "fontSize": "0.75rem",
+                                          "height": "2rem",
+                                          "minWidth": "2rem",
+                                          "padding": "0 1rem",
+                                        },
+                                      },
+                                      "buttons": Object {
+                                        "danger": Object {
+                                          "--contrast-color": "#fff",
+                                          "--main-color": "#DC2C10",
+                                        },
+                                        "primary": Object {
+                                          "--contrast-color": "#fff",
+                                          "--main-color": "#4E3FCE",
+                                          "backgroundColor": "#4E3FCE",
+                                          "color": "#fff",
+                                        },
+                                        "success": Object {
+                                          "--contrast-color": "#FFF",
+                                          "--main-color": "#28C081",
+                                        },
+                                      },
+                                      "colors": Object {
+                                        "black": "#000e1a",
+                                        "blacks": Array [
+                                          "rgba(0,0,0,.0125)",
+                                          "rgba(0,0,0,.025)",
+                                          "rgba(0,0,0,.05)",
+                                          "rgba(0,0,0,.1)",
+                                          "rgba(0,0,0,.2)",
+                                          "rgba(0,0,0,.3)",
+                                          "rgba(0,0,0,.4)",
+                                          "rgba(0,0,0,.5)",
+                                          "rgba(0,0,0,.6)",
+                                          "rgba(0,0,0,.7)",
+                                          "rgba(0,0,0,.8)",
+                                          "rgba(0,0,0,.9)",
+                                        ],
+                                        "blue": "#3259D6",
+                                        "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
+                                        "dark-gray": "#333",
+                                        "grey": "#CCC",
+                                        "info": "#36ADF1",
+                                        "light-gray": "#eee",
+                                        "light-silver": "#aaa",
+                                        "mid-gray": "#555",
+                                        "moon-gray": "#ccc",
+                                        "near-black": "#111",
+                                        "near-white": "#f4f4f4",
+                                        "primary": "#4E3FCE",
+                                        "primary-dark": "#3e32a4",
+                                        "primary-light": "#7165d7",
+                                        "silver": "#999",
+                                        "success": "#28C081",
+                                        "transparent": "transparent",
+                                        "warning": "#FD9D28",
+                                        "white": "#fff",
+                                        "whites": Array [
+                                          "rgba(255,255,255,.0125)",
+                                          "rgba(255,255,255,.025)",
+                                          "rgba(255,255,255,.05)",
+                                          "rgba(255,255,255,.1)",
+                                          "rgba(255,255,255,.2)",
+                                          "rgba(255,255,255,.3)",
+                                          "rgba(255,255,255,.4)",
+                                          "rgba(255,255,255,.5)",
+                                          "rgba(255,255,255,.6)",
+                                          "rgba(255,255,255,.7)",
+                                          "rgba(255,255,255,.8)",
+                                          "rgba(255,255,255,.9)",
+                                        ],
+                                      },
+                                      "fontSizes": Array [
+                                        12,
+                                        14,
+                                        16,
+                                        20,
+                                        24,
+                                        32,
+                                        48,
+                                        64,
+                                      ],
+                                      "fontWeights": Array [
+                                        0,
+                                        300,
+                                        400,
+                                        600,
+                                        700,
+                                      ],
+                                      "fonts": Object {
+                                        "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
+                                        "serif": "athelas, georgia, times, serif",
+                                      },
+                                      "heights": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "letterSpacings": Array [
+                                        0,
+                                        1,
+                                        2,
+                                        4,
+                                        8,
+                                      ],
+                                      "lineHeights": Object {
+                                        "copy": 1.5,
+                                        "solid": 1,
+                                        "title": 1.25,
+                                      },
+                                      "maxHeights": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "maxWidths": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                        512,
+                                        768,
+                                        1024,
+                                        1536,
+                                      ],
+                                      "messageStyle": Object {
+                                        "base": Object {
+                                          "backgroundColor": "#f6f6f6",
+                                          "borderColor": "#AAA",
+                                          "color": "#666",
+                                        },
+                                        "danger": Object {
+                                          "backgroundColor": "#fbe9e7",
+                                          "borderColor": "#DC2C10",
+                                          "color": "#841a09",
+                                        },
+                                        "info": Object {
+                                          "backgroundColor": "#eaf6fd",
+                                          "borderColor": "#36ADF1",
+                                          "color": "#206790",
+                                        },
+                                        "success": Object {
+                                          "backgroundColor": "#e9f8f2",
+                                          "borderColor": "#28C081",
+                                          "color": "#18734d",
+                                        },
+                                        "warning": Object {
+                                          "backgroundColor": "#fef5e9",
+                                          "borderColor": "#FD9D28",
+                                          "color": "#975e18",
+                                        },
+                                      },
+                                      "minHeights": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "minWidths": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "opacity": Object {
+                                        "disabled": 0.4,
+                                      },
+                                      "radii": Array [
+                                        "0",
+                                        "4px",
+                                        "8px",
+                                        "16px",
+                                      ],
+                                      "shadows": Array [
+                                        "0",
+                                        "0px 2px 4px rgba(0, 0, 0, 0.1)",
+                                        "0 7px 14px rgba(50,50,93,.1)",
+                                      ],
+                                      "space": Array [
+                                        0,
+                                        4,
+                                        8,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "width": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "zIndices": Array [
+                                        0,
+                                        9,
+                                        99,
+                                        999,
+                                        9999,
+                                      ],
+                                    },
+                                  },
+                                  "displayName": "styled.s",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-eiqfgm",
+                                  "target": "s",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                },
+                                "span": Object {
+                                  "$$typeof": Symbol(react.forward_ref),
+                                  "attrs": Array [],
+                                  "componentStyle": ComponentStyle {
+                                    "componentId": "sc-jZIEzD",
+                                    "isStatic": false,
+                                    "rules": Array [
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+  ",
+                                      [Function],
+                                      "
+",
+                                    ],
+                                  },
+                                  "defaultProps": Object {
+                                    "color": "copyColor",
+                                    "fontFamily": "sansSerif",
+                                    "fontSize": 2,
+                                    "fontWeight": 2,
+                                    "lineHeight": "copy",
+                                    "textAlign": "left",
+                                    "theme": Object {
+                                      "borderWidths": Array [
+                                        "0",
+                                        "1px",
+                                        "2px",
+                                        "4px",
+                                      ],
+                                      "borders": Array [
+                                        0,
+                                        "1px solid transparent",
+                                      ],
+                                      "buttonSizes": Object {
+                                        "large": Object {
+                                          "fontSize": "1.5rem",
+                                          "height": "4rem",
+                                          "minWidth": "4rem",
+                                        },
+                                        "medium": Object {
+                                          "fontSize": "1rem",
+                                          "height": "3rem",
+                                          "minWidth": "3rem",
+                                        },
+                                        "small": Object {
+                                          "fontSize": "0.75rem",
+                                          "height": "2rem",
+                                          "minWidth": "2rem",
+                                          "padding": "0 1rem",
+                                        },
+                                      },
+                                      "buttons": Object {
+                                        "danger": Object {
+                                          "--contrast-color": "#fff",
+                                          "--main-color": "#DC2C10",
+                                        },
+                                        "primary": Object {
+                                          "--contrast-color": "#fff",
+                                          "--main-color": "#4E3FCE",
+                                          "backgroundColor": "#4E3FCE",
+                                          "color": "#fff",
+                                        },
+                                        "success": Object {
+                                          "--contrast-color": "#FFF",
+                                          "--main-color": "#28C081",
+                                        },
+                                      },
+                                      "colors": Object {
+                                        "black": "#000e1a",
+                                        "blacks": Array [
+                                          "rgba(0,0,0,.0125)",
+                                          "rgba(0,0,0,.025)",
+                                          "rgba(0,0,0,.05)",
+                                          "rgba(0,0,0,.1)",
+                                          "rgba(0,0,0,.2)",
+                                          "rgba(0,0,0,.3)",
+                                          "rgba(0,0,0,.4)",
+                                          "rgba(0,0,0,.5)",
+                                          "rgba(0,0,0,.6)",
+                                          "rgba(0,0,0,.7)",
+                                          "rgba(0,0,0,.8)",
+                                          "rgba(0,0,0,.9)",
+                                        ],
+                                        "blue": "#3259D6",
+                                        "copyColor": "#3F3D4B",
+                                        "danger": "#DC2C10",
+                                        "dark-gray": "#333",
+                                        "grey": "#CCC",
+                                        "info": "#36ADF1",
+                                        "light-gray": "#eee",
+                                        "light-silver": "#aaa",
+                                        "mid-gray": "#555",
+                                        "moon-gray": "#ccc",
+                                        "near-black": "#111",
+                                        "near-white": "#f4f4f4",
+                                        "primary": "#4E3FCE",
+                                        "primary-dark": "#3e32a4",
+                                        "primary-light": "#7165d7",
+                                        "silver": "#999",
+                                        "success": "#28C081",
+                                        "transparent": "transparent",
+                                        "warning": "#FD9D28",
+                                        "white": "#fff",
+                                        "whites": Array [
+                                          "rgba(255,255,255,.0125)",
+                                          "rgba(255,255,255,.025)",
+                                          "rgba(255,255,255,.05)",
+                                          "rgba(255,255,255,.1)",
+                                          "rgba(255,255,255,.2)",
+                                          "rgba(255,255,255,.3)",
+                                          "rgba(255,255,255,.4)",
+                                          "rgba(255,255,255,.5)",
+                                          "rgba(255,255,255,.6)",
+                                          "rgba(255,255,255,.7)",
+                                          "rgba(255,255,255,.8)",
+                                          "rgba(255,255,255,.9)",
+                                        ],
+                                      },
+                                      "fontSizes": Array [
+                                        12,
+                                        14,
+                                        16,
+                                        20,
+                                        24,
+                                        32,
+                                        48,
+                                        64,
+                                      ],
+                                      "fontWeights": Array [
+                                        0,
+                                        300,
+                                        400,
+                                        600,
+                                        700,
+                                      ],
+                                      "fonts": Object {
+                                        "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
+                                        "serif": "athelas, georgia, times, serif",
+                                      },
+                                      "heights": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "letterSpacings": Array [
+                                        0,
+                                        1,
+                                        2,
+                                        4,
+                                        8,
+                                      ],
+                                      "lineHeights": Object {
+                                        "copy": 1.5,
+                                        "solid": 1,
+                                        "title": 1.25,
+                                      },
+                                      "maxHeights": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "maxWidths": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                        512,
+                                        768,
+                                        1024,
+                                        1536,
+                                      ],
+                                      "messageStyle": Object {
+                                        "base": Object {
+                                          "backgroundColor": "#f6f6f6",
+                                          "borderColor": "#AAA",
+                                          "color": "#666",
+                                        },
+                                        "danger": Object {
+                                          "backgroundColor": "#fbe9e7",
+                                          "borderColor": "#DC2C10",
+                                          "color": "#841a09",
+                                        },
+                                        "info": Object {
+                                          "backgroundColor": "#eaf6fd",
+                                          "borderColor": "#36ADF1",
+                                          "color": "#206790",
+                                        },
+                                        "success": Object {
+                                          "backgroundColor": "#e9f8f2",
+                                          "borderColor": "#28C081",
+                                          "color": "#18734d",
+                                        },
+                                        "warning": Object {
+                                          "backgroundColor": "#fef5e9",
+                                          "borderColor": "#FD9D28",
+                                          "color": "#975e18",
+                                        },
+                                      },
+                                      "minHeights": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "minWidths": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "opacity": Object {
+                                        "disabled": 0.4,
+                                      },
+                                      "radii": Array [
+                                        "0",
+                                        "4px",
+                                        "8px",
+                                        "16px",
+                                      ],
+                                      "shadows": Array [
+                                        "0",
+                                        "0px 2px 4px rgba(0, 0, 0, 0.1)",
+                                        "0 7px 14px rgba(50,50,93,.1)",
+                                      ],
+                                      "space": Array [
+                                        0,
+                                        4,
+                                        8,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "width": Array [
+                                        0,
+                                        16,
+                                        32,
+                                        64,
+                                        128,
+                                        256,
+                                      ],
+                                      "zIndices": Array [
+                                        0,
+                                        9,
+                                        99,
+                                        999,
+                                        9999,
+                                      ],
+                                    },
+                                  },
+                                  "displayName": "styled.span",
+                                  "foldedComponentIds": Array [],
+                                  "render": [Function],
+                                  "styledComponentId": "sc-jZIEzD",
+                                  "target": "span",
+                                  "toString": [Function],
+                                  "warnTooManyClasses": [Function],
+                                  "withComponent": [Function],
+                                },
+                                "styledComponentId": "sc-bGbZqa",
+                                "target": "div",
+                                "toString": [Function],
+                                "warnTooManyClasses": [Function],
+                                "withComponent": [Function],
                               }
-                              forwardedRef={null}
-                              hoverColor="primary-light"
+                            }
+                            forwardedRef={null}
+                            hoverColor="primary-light"
+                            href="http://test.com"
+                            target="_blank"
+                            theme={
+                              Object {
+                                "borderWidths": Array [
+                                  "0",
+                                  "1px",
+                                  "2px",
+                                  "4px",
+                                ],
+                                "borders": Array [
+                                  0,
+                                  "1px solid transparent",
+                                ],
+                                "buttonSizes": Object {
+                                  "large": Object {
+                                    "fontSize": "1.5rem",
+                                    "height": "4rem",
+                                    "minWidth": "4rem",
+                                  },
+                                  "medium": Object {
+                                    "fontSize": "1rem",
+                                    "height": "3rem",
+                                    "minWidth": "3rem",
+                                  },
+                                  "small": Object {
+                                    "fontSize": "0.75rem",
+                                    "height": "2rem",
+                                    "minWidth": "2rem",
+                                    "padding": "0 1rem",
+                                  },
+                                },
+                                "buttons": Object {
+                                  "danger": Object {
+                                    "--contrast-color": "#fff",
+                                    "--main-color": "#DC2C10",
+                                  },
+                                  "primary": Object {
+                                    "--contrast-color": "#fff",
+                                    "--main-color": "#4E3FCE",
+                                    "backgroundColor": "#4E3FCE",
+                                    "color": "#fff",
+                                  },
+                                  "success": Object {
+                                    "--contrast-color": "#FFF",
+                                    "--main-color": "#28C081",
+                                  },
+                                },
+                                "colors": Object {
+                                  "black": "#000e1a",
+                                  "blacks": Array [
+                                    "rgba(0,0,0,.0125)",
+                                    "rgba(0,0,0,.025)",
+                                    "rgba(0,0,0,.05)",
+                                    "rgba(0,0,0,.1)",
+                                    "rgba(0,0,0,.2)",
+                                    "rgba(0,0,0,.3)",
+                                    "rgba(0,0,0,.4)",
+                                    "rgba(0,0,0,.5)",
+                                    "rgba(0,0,0,.6)",
+                                    "rgba(0,0,0,.7)",
+                                    "rgba(0,0,0,.8)",
+                                    "rgba(0,0,0,.9)",
+                                  ],
+                                  "blue": "#3259D6",
+                                  "copyColor": "#3F3D4B",
+                                  "danger": "#DC2C10",
+                                  "dark-gray": "#333",
+                                  "grey": "#CCC",
+                                  "info": "#36ADF1",
+                                  "light-gray": "#eee",
+                                  "light-silver": "#aaa",
+                                  "mid-gray": "#555",
+                                  "moon-gray": "#ccc",
+                                  "near-black": "#111",
+                                  "near-white": "#f4f4f4",
+                                  "primary": "#4E3FCE",
+                                  "primary-dark": "#3e32a4",
+                                  "primary-light": "#7165d7",
+                                  "silver": "#999",
+                                  "success": "#28C081",
+                                  "transparent": "transparent",
+                                  "warning": "#FD9D28",
+                                  "white": "#fff",
+                                  "whites": Array [
+                                    "rgba(255,255,255,.0125)",
+                                    "rgba(255,255,255,.025)",
+                                    "rgba(255,255,255,.05)",
+                                    "rgba(255,255,255,.1)",
+                                    "rgba(255,255,255,.2)",
+                                    "rgba(255,255,255,.3)",
+                                    "rgba(255,255,255,.4)",
+                                    "rgba(255,255,255,.5)",
+                                    "rgba(255,255,255,.6)",
+                                    "rgba(255,255,255,.7)",
+                                    "rgba(255,255,255,.8)",
+                                    "rgba(255,255,255,.9)",
+                                  ],
+                                },
+                                "fontSizes": Array [
+                                  12,
+                                  14,
+                                  16,
+                                  20,
+                                  24,
+                                  32,
+                                  48,
+                                  64,
+                                ],
+                                "fontWeights": Array [
+                                  0,
+                                  300,
+                                  400,
+                                  600,
+                                  700,
+                                ],
+                                "fonts": Object {
+                                  "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
+                                  "serif": "athelas, georgia, times, serif",
+                                },
+                                "heights": Array [
+                                  0,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                ],
+                                "letterSpacings": Array [
+                                  0,
+                                  1,
+                                  2,
+                                  4,
+                                  8,
+                                ],
+                                "lineHeights": Object {
+                                  "copy": 1.5,
+                                  "solid": 1,
+                                  "title": 1.25,
+                                },
+                                "maxHeights": Array [
+                                  0,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                ],
+                                "maxWidths": Array [
+                                  0,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                  512,
+                                  768,
+                                  1024,
+                                  1536,
+                                ],
+                                "messageStyle": Object {
+                                  "base": Object {
+                                    "backgroundColor": "#f6f6f6",
+                                    "borderColor": "#AAA",
+                                    "color": "#666",
+                                  },
+                                  "danger": Object {
+                                    "backgroundColor": "#fbe9e7",
+                                    "borderColor": "#DC2C10",
+                                    "color": "#841a09",
+                                  },
+                                  "info": Object {
+                                    "backgroundColor": "#eaf6fd",
+                                    "borderColor": "#36ADF1",
+                                    "color": "#206790",
+                                  },
+                                  "success": Object {
+                                    "backgroundColor": "#e9f8f2",
+                                    "borderColor": "#28C081",
+                                    "color": "#18734d",
+                                  },
+                                  "warning": Object {
+                                    "backgroundColor": "#fef5e9",
+                                    "borderColor": "#FD9D28",
+                                    "color": "#975e18",
+                                  },
+                                },
+                                "minHeights": Array [
+                                  0,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                ],
+                                "minWidths": Array [
+                                  0,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                ],
+                                "opacity": Object {
+                                  "disabled": 0.4,
+                                },
+                                "radii": Array [
+                                  "0",
+                                  "4px",
+                                  "8px",
+                                  "16px",
+                                ],
+                                "shadows": Array [
+                                  "0",
+                                  "0px 2px 4px rgba(0, 0, 0, 0.1)",
+                                  "0 7px 14px rgba(50,50,93,.1)",
+                                ],
+                                "space": Array [
+                                  0,
+                                  4,
+                                  8,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                ],
+                                "width": Array [
+                                  0,
+                                  16,
+                                  32,
+                                  64,
+                                  128,
+                                  256,
+                                ],
+                                "zIndices": Array [
+                                  0,
+                                  9,
+                                  99,
+                                  999,
+                                  9999,
+                                ],
+                              }
+                            }
+                          >
+                            <a
+                              className="c5 c9"
+                              color="primary"
+                              fontSize={1}
+                              fontWeight={3}
                               href="http://test.com"
-                              lineHeight="copy"
                               target="_blank"
-                              textAlign="left"
-                              theme={
-                                Object {
-                                  "borderWidths": Array [
-                                    "0",
-                                    "1px",
-                                    "2px",
-                                    "4px",
-                                  ],
-                                  "borders": Array [
-                                    0,
-                                    "1px solid transparent",
-                                  ],
-                                  "buttonSizes": Object {
-                                    "large": Object {
-                                      "fontSize": "1.5rem",
-                                      "height": "4rem",
-                                      "minWidth": "4rem",
-                                    },
-                                    "medium": Object {
-                                      "fontSize": "1rem",
-                                      "height": "3rem",
-                                      "minWidth": "3rem",
-                                    },
-                                    "small": Object {
-                                      "fontSize": "0.75rem",
-                                      "height": "2rem",
-                                      "minWidth": "2rem",
-                                      "padding": "0 1rem",
-                                    },
-                                  },
-                                  "buttons": Object {
-                                    "danger": Object {
-                                      "--contrast-color": "#fff",
-                                      "--main-color": "#DC2C10",
-                                    },
-                                    "primary": Object {
-                                      "--contrast-color": "#fff",
-                                      "--main-color": "#4E3FCE",
-                                      "backgroundColor": "#4E3FCE",
-                                      "color": "#fff",
-                                    },
-                                    "success": Object {
-                                      "--contrast-color": "#FFF",
-                                      "--main-color": "#28C081",
-                                    },
-                                  },
-                                  "colors": Object {
-                                    "black": "#000e1a",
-                                    "blacks": Array [
-                                      "rgba(0,0,0,.0125)",
-                                      "rgba(0,0,0,.025)",
-                                      "rgba(0,0,0,.05)",
-                                      "rgba(0,0,0,.1)",
-                                      "rgba(0,0,0,.2)",
-                                      "rgba(0,0,0,.3)",
-                                      "rgba(0,0,0,.4)",
-                                      "rgba(0,0,0,.5)",
-                                      "rgba(0,0,0,.6)",
-                                      "rgba(0,0,0,.7)",
-                                      "rgba(0,0,0,.8)",
-                                      "rgba(0,0,0,.9)",
-                                    ],
-                                    "blue": "#3259D6",
-                                    "copyColor": "#3F3D4B",
-                                    "danger": "#DC2C10",
-                                    "dark-gray": "#333",
-                                    "grey": "#CCC",
-                                    "info": "#36ADF1",
-                                    "light-gray": "#eee",
-                                    "light-silver": "#aaa",
-                                    "mid-gray": "#555",
-                                    "moon-gray": "#ccc",
-                                    "near-black": "#111",
-                                    "near-white": "#f4f4f4",
-                                    "primary": "#4E3FCE",
-                                    "primary-dark": "#3e32a4",
-                                    "primary-light": "#7165d7",
-                                    "silver": "#999",
-                                    "success": "#28C081",
-                                    "transparent": "transparent",
-                                    "warning": "#FD9D28",
-                                    "white": "#fff",
-                                    "whites": Array [
-                                      "rgba(255,255,255,.0125)",
-                                      "rgba(255,255,255,.025)",
-                                      "rgba(255,255,255,.05)",
-                                      "rgba(255,255,255,.1)",
-                                      "rgba(255,255,255,.2)",
-                                      "rgba(255,255,255,.3)",
-                                      "rgba(255,255,255,.4)",
-                                      "rgba(255,255,255,.5)",
-                                      "rgba(255,255,255,.6)",
-                                      "rgba(255,255,255,.7)",
-                                      "rgba(255,255,255,.8)",
-                                      "rgba(255,255,255,.9)",
-                                    ],
-                                  },
-                                  "fontSizes": Array [
-                                    12,
-                                    14,
-                                    16,
-                                    20,
-                                    24,
-                                    32,
-                                    48,
-                                    64,
-                                  ],
-                                  "fontWeights": Array [
-                                    0,
-                                    300,
-                                    400,
-                                    600,
-                                    700,
-                                  ],
-                                  "fonts": Object {
-                                    "sansSerif": "\\"Source Sans Pro\\", -apple-system, sans-serif",
-                                    "serif": "athelas, georgia, times, serif",
-                                  },
-                                  "heights": Array [
-                                    0,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                  ],
-                                  "letterSpacings": Array [
-                                    0,
-                                    1,
-                                    2,
-                                    4,
-                                    8,
-                                  ],
-                                  "lineHeights": Object {
-                                    "copy": 1.5,
-                                    "solid": 1,
-                                    "title": 1.25,
-                                  },
-                                  "maxHeights": Array [
-                                    0,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                  ],
-                                  "maxWidths": Array [
-                                    0,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                    512,
-                                    768,
-                                    1024,
-                                    1536,
-                                  ],
-                                  "messageStyle": Object {
-                                    "base": Object {
-                                      "backgroundColor": "#f6f6f6",
-                                      "borderColor": "#AAA",
-                                      "color": "#666",
-                                    },
-                                    "danger": Object {
-                                      "backgroundColor": "#fbe9e7",
-                                      "borderColor": "#DC2C10",
-                                      "color": "#841a09",
-                                    },
-                                    "info": Object {
-                                      "backgroundColor": "#eaf6fd",
-                                      "borderColor": "#36ADF1",
-                                      "color": "#206790",
-                                    },
-                                    "success": Object {
-                                      "backgroundColor": "#e9f8f2",
-                                      "borderColor": "#28C081",
-                                      "color": "#18734d",
-                                    },
-                                    "warning": Object {
-                                      "backgroundColor": "#fef5e9",
-                                      "borderColor": "#FD9D28",
-                                      "color": "#975e18",
-                                    },
-                                  },
-                                  "minHeights": Array [
-                                    0,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                  ],
-                                  "minWidths": Array [
-                                    0,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                  ],
-                                  "opacity": Object {
-                                    "disabled": 0.4,
-                                  },
-                                  "radii": Array [
-                                    "0",
-                                    "4px",
-                                    "8px",
-                                    "16px",
-                                  ],
-                                  "shadows": Array [
-                                    "0",
-                                    "0px 2px 4px rgba(0, 0, 0, 0.1)",
-                                    "0 7px 14px rgba(50,50,93,.1)",
-                                  ],
-                                  "space": Array [
-                                    0,
-                                    4,
-                                    8,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                  ],
-                                  "width": Array [
-                                    0,
-                                    16,
-                                    32,
-                                    64,
-                                    128,
-                                    256,
-                                  ],
-                                  "zIndices": Array [
-                                    0,
-                                    9,
-                                    99,
-                                    999,
-                                    9999,
-                                  ],
-                                }
-                              }
                             >
-                              <a
-                                className="c5 c9"
-                                color="primary"
-                                fontFamily="sansSerif"
-                                fontSize={1}
-                                fontWeight={3}
-                                href="http://test.com"
-                                target="_blank"
-                              >
-                                Link
-                              </a>
-                            </StyledComponent>
-                          </Styled(Text)>
+                              Link
+                            </a>
+                          </StyledComponent>
                         </Link>
                       </div>
                     </StyledComponent>


### PR DESCRIPTION
adding a color property to a element inside Flash components causes unintended consequences due to css specificity. Only target Link components instead to reduce the scope of the styles. It might be better to adopt a sub component pattern in the future like react bootstrap does.

https://react-bootstrap.github.io/components/alerts/#alert-link-props